### PR TITLE
Fix balance tests

### DIFF
--- a/balance_test.go
+++ b/balance_test.go
@@ -35,16 +35,16 @@ func getTestSettings() Settings {
 func Test_Functionality(t *testing.T) {
 	t.Run("handler fn called for every incoming packet", func(t *testing.T) {
 		noop := func(ignored any) {}
-		c := make(chan gopacket.Packet)
+		pkts := make(chan gopacket.Packet)
 		b := New(noop, getTestSettings())
 		assert.NotNil(t, b)
-		b.Start(c)
+		b.Start(pkts)
 
 		runs := 100
 		for i := 0; i < runs; i++ {
-			c <- gopacket.NewPacket(udpDNSPacketBytes, layers.LayerTypeEthernet, gopacket.Default)
+			pkts <- gopacket.NewPacket(udpDNSPacketBytes, layers.LayerTypeEthernet, gopacket.Default)
 		}
-		b.Stop()
+		b.Stop() // blocking
 
 		assert.Equal(t, int64(runs), b.Stats.Processed())
 	})

--- a/worker.go
+++ b/worker.go
@@ -24,7 +24,7 @@ type workerSettings struct {
 	handler         Handler
 	completed       chan<- *worker
 	queueSize       int
-	finished        func()
+	postStop        func()
 	shutdownTimeout time.Duration
 }
 
@@ -54,8 +54,8 @@ func (w *worker) Start() error {
 			select {
 			case <-w.ctx.Done():
 				w.drainRequests()
-				if w.settings.finished != nil {
-					w.settings.finished()
+				if w.settings.postStop != nil {
+					w.settings.postStop()
 				}
 				return
 			case x := <-w.requests:


### PR DESCRIPTION
When the balancer's `Stop` function is called, the function will block for two conditions: (1) the wait group for all worker threads to be `Done` and (2) the balancer's `completed` channel to be full drained. After both conditions are fulfilled, all data has been completely handled, and it is safe to shutdown the balancer.