### PR TITLE
Cleanup pkg exports and fix a few race conditions

### DIFF
--- a/balance.go
+++ b/balance.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -24,51 +25,41 @@ var Default = Settings{
 	WorkerQueueSize: 10000,
 	ShutdownTimeout: 30 * time.Second,
 	Backoff: backoff.WithMaxRetries(
-		NewExponentialBackOff(),
+		newExponentialBackOff(),
 		10,
 	),
 }
 
-type BalancerStats struct {
-	processed          int64
-	failedBusy         int64
-	failedType         int64
-	failedHash         int64
-	processedPerWorker map[string]int64
+type Stats struct {
+	processed          atomic.Uint64
+	failedBusy         atomic.Uint64
+	failedType         atomic.Uint64
+	failedHash         atomic.Uint64
+	processedPerWorker map[string]uint64
 }
 
-func NewStats() BalancerStats {
-	return BalancerStats{
-		processed:          0,
-		failedBusy:         0,
-		failedType:         0,
-		failedHash:         0,
-		processedPerWorker: make(map[string]int64),
-	}
+func (b *Stats) Processed() uint64 {
+	return b.processed.Load()
 }
 
-func (b *BalancerStats) Processed() int64 {
-	return b.processed
+func (b *Stats) FailedBusy() uint64 {
+	return b.failedBusy.Load()
 }
 
-func (b *BalancerStats) FailedBusy() int64 {
-	return b.failedBusy
+func (b *Stats) FailedType() uint64 {
+	return b.failedType.Load()
 }
 
-func (b *BalancerStats) FailedType() int64 {
-	return b.failedType
+func (b *Stats) FailedHash() uint64 {
+	return b.failedHash.Load()
 }
 
-func (b *BalancerStats) FailedHash() int64 {
-	return b.failedHash
-}
-
-func (b *BalancerStats) ProcessedPerWorker() map[string]int64 {
+func (b *Stats) ProcessedPerWorker() map[string]uint64 {
 	return b.processedPerWorker
 }
 
 type pool struct {
-	lock sync.Mutex
+	lock sync.RWMutex
 	heap Heap
 	wg   sync.WaitGroup
 }
@@ -81,8 +72,16 @@ func newPool(numWorkers int) *pool {
 	return mp
 }
 
+func newExponentialBackOff() backoff.BackOff {
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = 1 * time.Microsecond
+	expBackoff.RandomizationFactor = 0.1
+	expBackoff.Multiplier = 1.5
+	return expBackoff
+}
+
 type Balancer struct {
-	Stats BalancerStats
+	Stats Stats
 
 	ctx       context.Context
 	cancel    context.CancelFunc
@@ -90,14 +89,6 @@ type Balancer struct {
 	blocker   *blocker
 	flowTable *flowLookup
 	p         *pool
-}
-
-func NewExponentialBackOff() backoff.BackOff {
-	expBackoff := backoff.NewExponentialBackOff()
-	expBackoff.InitialInterval = 1 * time.Microsecond
-	expBackoff.RandomizationFactor = 0.3
-	expBackoff.Multiplier = 2
-	return expBackoff
 }
 
 func New(processFn Handler, settings Settings) *Balancer {
@@ -122,23 +113,25 @@ func New(processFn Handler, settings Settings) *Balancer {
 			return nil
 		}
 		heap.Push(&p.heap, w)
-		w.Start()
+		w.start()
 	}
 	heap.Init(&p.heap)
 
 	return &Balancer{
-		Stats:     NewStats(),
+		Stats: Stats{
+			processedPerWorker: make(map[string]uint64),
+		},
 		ctx:       ctx,
 		cancel:    cancel,
 		p:         p,
 		completed: completed,
 		blocker: NewBlocker(
 			backoff.WithMaxRetries(
-				NewExponentialBackOff(),
+				newExponentialBackOff(),
 				10,
 			),
 		),
-		flowTable: NewFlowLookup(),
+		flowTable: newFlowLookup(),
 	}
 }
 
@@ -148,13 +141,19 @@ func (b *Balancer) Start(in <-chan gopacket.Packet) {
 }
 
 func (b *Balancer) Stop() {
+	defer close(b.completed)
 	b.cancel()
 	b.p.wg.Wait()
-	close(b.completed)
+	b.blocker.Wait(func() error {
+		if len(b.completed) > 0 {
+			return errors.New("completed channel not empty")
+		}
+		return nil
+	})
 }
 
 func (b *Balancer) Delete(hash string) {
-	b.flowTable.Delete(hash)
+	b.flowTable.delete(hash)
 }
 
 func (b *Balancer) handleCompleted() {
@@ -168,7 +167,8 @@ func (b *Balancer) handleCompleted() {
 				return
 			}
 			b.updateHeap(worker)
-			b.Stats.processed++
+			b.Stats.processed.Add(1)
+			// this is a race condition
 			b.Stats.processedPerWorker[worker.uuid]++
 			// b.print()
 		}
@@ -192,39 +192,35 @@ func (b *Balancer) handleDispatch(in <-chan gopacket.Packet) {
 func (b *Balancer) dispatch(pkt gopacket.Packet) {
 	hash, err := hash(pkt)
 	if err != nil {
-		b.Stats.failedHash++
+		b.Stats.failedHash.Add(1)
 		return
 	}
 
-	waitFn := b.nextWorkerIsBusy
-	w, found := b.flowTable.Load(hash)
+	selectedWorker := b.p.heap[0]
+	existingWorker, found := b.flowTable.load(hash)
 	if found {
-		waitFn = b.getIsQueueFull(w)
+		selectedWorker = existingWorker
 	}
 
-	err = b.blocker.Wait(waitFn)
+	err = b.blocker.Wait(b.queueIsNotFull(selectedWorker))
 	if err != nil {
-		b.Stats.failedBusy++
+		b.Stats.failedBusy.Add(1)
 		return
 	}
 
 	b.p.lock.Lock()
 	defer b.p.lock.Unlock()
 	if found {
-		w.requests <- pkt
-		w.pending++
-		heap.Fix(&b.p.heap, w.idx)
+		selectedWorker.requests <- pkt
+		selectedWorker.pending++
+		heap.Fix(&b.p.heap, selectedWorker.idx)
 	} else {
 		w := heap.Pop(&b.p.heap).(*worker)
 		w.requests <- pkt
 		heap.Push(&b.p.heap, w)
 		w.pending++
-		b.flowTable.Store(hash, w)
+		b.flowTable.store(hash, w)
 	}
-}
-
-func (b *Balancer) nextWorkerIsBusy() error {
-	return b.getIsQueueFull(b.p.heap[0])()
 }
 
 func (b *Balancer) updateHeap(w *worker) {
@@ -235,10 +231,10 @@ func (b *Balancer) updateHeap(w *worker) {
 	heap.Push(&b.p.heap, mruWorker)
 }
 
-func (b *Balancer) getIsQueueFull(w *worker) backoff.Operation {
+func (b *Balancer) queueIsNotFull(w *worker) func() error {
 	return func() error {
 		if cap(w.requests) == len(w.requests) {
-			return errors.New("worker queue is full")
+			return errors.New("queue is full")
 		}
 		return nil
 	}

--- a/balance_test.go
+++ b/balance_test.go
@@ -32,8 +32,41 @@ func getTestSettings() Settings {
 	return s
 }
 
+var noop = func(ignored any) {}
+
+func Test_StartAndStop(t *testing.T) {
+	t.Run("start", func(t *testing.T) {
+		c := make(chan gopacket.Packet)
+		b := New(noop, getTestSettings())
+		assert.NotNil(t, b)
+		assert.NotPanics(t, func() {
+			b.Start(c)
+		})
+	})
+
+	t.Run("stop with no start", func(t *testing.T) {
+		b := New(noop, getTestSettings())
+		assert.NotNil(t, b)
+		assert.NotPanics(t, func() {
+			b.Stop()
+		})
+	})
+
+	t.Run("start and stop", func(t *testing.T) {
+		c := make(chan gopacket.Packet)
+		b := New(noop, getTestSettings())
+		assert.NotNil(t, b)
+		assert.NotPanics(t, func() {
+			b.Start(c)
+		})
+		assert.NotPanics(t, func() {
+			b.Stop()
+		})
+	})
+}
+
 func Test_Functionality(t *testing.T) {
-	t.Run("handler fn called for every incoming packet", func(t *testing.T) {
+	t.Run("handler fn called for every incoming packet - single-threaded", func(t *testing.T) {
 		noop := func(ignored any) {}
 		c := make(chan gopacket.Packet)
 		b := New(noop, getTestSettings())
@@ -46,6 +79,6 @@ func Test_Functionality(t *testing.T) {
 		}
 		b.Stop()
 
-		assert.Equal(t, int64(runs), b.Stats.Processed())
+		assert.Equal(t, uint64(runs), b.Stats.Processed())
 	})
 }

--- a/flowlookup.go
+++ b/flowlookup.go
@@ -10,32 +10,32 @@ type flowLookup struct {
 	lookup map[string]*worker
 }
 
-func NewFlowLookup() *flowLookup {
+func newFlowLookup() *flowLookup {
 	return &flowLookup{
 		lookup: make(map[string]*worker),
 	}
 }
 
-func (f *flowLookup) Store(hash string, w *worker) {
+func (f *flowLookup) store(hash string, w *worker) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	f.lookup[hash] = w
 }
 
-func (f *flowLookup) Load(hash string) (w *worker, found bool) {
+func (f *flowLookup) load(hash string) (w *worker, found bool) {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	w, found = f.lookup[hash]
 	return
 }
 
-func (f *flowLookup) Delete(hash string) {
+func (f *flowLookup) delete(hash string) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	delete(f.lookup, hash)
 }
 
-func (f *flowLookup) Print() {
+func (f *flowLookup) print() {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	fmt.Println("\n\n==============================================================")

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/puzpuzpuz/xsync v1.5.2 // indirect
+	github.com/puzpuzpuz/xsync/v2 v2.4.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,10 @@ github.com/gopacket/gopacket v1.1.0 h1:zKPCsVPcVt1B2AJyzSM44iaFVuFFSIyu0imExpPmy
 github.com/gopacket/gopacket v1.1.0/go.mod h1:HavMeONEl7W9036of9LbSWoonqhH7HA1+ZRO+rMIvFs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/puzpuzpuz/xsync v1.5.2 h1:yRAP4wqSOZG+/4pxJ08fPTwrfL0IzE/LKQ/cw509qGY=
+github.com/puzpuzpuz/xsync v1.5.2/go.mod h1:K98BYhX3k1dQ2M63t1YNVDanbwUPmBCAhNmVrrxfiGg=
+github.com/puzpuzpuz/xsync/v2 v2.4.0 h1:5sXAMHrtx1bg9nbRZTOn8T4MkWe5V+o8yKRH02Eznag=
+github.com/puzpuzpuz/xsync/v2 v2.4.0/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
 github.com/satta/gommunityid v1.0.0 h1:H0utzmnUXlIC+YeWeUFaEKLnpRsv5kWnMO1+yQ9Wu60=
 github.com/satta/gommunityid v1.0.0/go.mod h1:dz6UCF9ERHtGjdv5LwOTgZxng/7IZm2spR/mXtTpLjc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/worker.go
+++ b/worker.go
@@ -45,7 +45,7 @@ func newWorker(ctx context.Context, settings workerSettings) (*worker, error) {
 	}, nil
 }
 
-func (w *worker) Start() error {
+func (w *worker) start() error {
 	if w.settings.handler == nil {
 		return errors.New("Failed to start worker: empty handler")
 	}


### PR DESCRIPTION
Race conditions with the Balancer Stats have been addressed. There is still one more race condition associated with the usage of the `processedPerWorker` map.

A few basic `NotPanics` unit tests have been added.

Code that doesn't need to be exported out of the package has been lower-cased.